### PR TITLE
editor.action.formatDocument in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ extend the status bar with own commands.
         "alignment": "left",
         "priority": 100,
         "include": "\.js",
-        "command": "editor.action.format"
+        "command": "editor.action.formatDocument"
     },{
         "text": "ctrl+h",
         "command": "workbench.action.tasks.runTask",


### PR DESCRIPTION
i guess it should be `editor.action.formatDocument`
https://code.visualstudio.com/docs/getstarted/keybindings#_rich-languages-editing
otherwise it does not work in current version of vscode