### PR TITLE
Allow script to be read from file

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,10 @@
                             "script": {
                                 "type": "string",
                                 "description": "script to execute if event is triggered."
+                            },
+                            "scriptFile": {
+                                "type": "string",
+                                "description": "File to read script from."
                             }
                         },
                         "required": [

--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "npm run compile && npm run compile-web",
+        "vscode:prepublish": "npm run compile",
         "esbuild": "esbuild ./src/extension.ts  --outdir=dist/  --platform=node --format=cjs --bundle --external:vscode",
         "compile": "npm run esbuild -- --minify",
         "watch": "npm run esbuild -- --sourcemap --watch",

--- a/package.json
+++ b/package.json
@@ -169,15 +169,15 @@
                             },
                             "scriptEvents": {
                                 "type": "array",
-                                "description": "list of events."
+                                "description": "list of events"
                             },
                             "script": {
                                 "type": "string",
-                                "description": "script to execute if event is triggered."
+                                "description": "script to execute if event is triggered"
                             },
                             "scriptFile": {
                                 "type": "string",
-                                "description": "File to read script from."
+                                "description": "Path to the javascript script file"
                             }
                         },
                         "required": [
@@ -302,11 +302,15 @@
                             },
                             "scriptEvents": {
                                 "type": "array",
-                                "description": "list of events."
+                                "description": "list of events"
                             },
                             "script": {
                                 "type": "string",
-                                "description": "script to execute if event is triggered."
+                                "description": "script to execute if event is triggered"
+                            },
+                            "scriptFile": {
+                                "type": "string",
+                                "description": "Path to the javascript script file"
                             }
                         },
                         "required": [
@@ -318,7 +322,7 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "npm run compile",
+        "vscode:prepublish": "npm run compile && npm run compile-web",
         "esbuild": "esbuild ./src/extension.ts  --outdir=dist/  --platform=node --format=cjs --bundle --external:vscode",
         "compile": "npm run esbuild -- --minify",
         "watch": "npm run esbuild -- --sourcemap --watch",

--- a/src/statusBarCommand.ts
+++ b/src/statusBarCommand.ts
@@ -92,6 +92,10 @@ export class StatusBarCommand implements vscode.Disposable {
       this.onDidChangeActiveTextEditor(vscode.window.activeTextEditor);
     } else if (config.scriptEvents && (config.script || config.scriptFile)) {
       const registerScriptEvents = () => {
+        for (const disposable of this.scriptEventDisposables) {
+          disposable.dispose();
+        }
+        this.scriptEventDisposables = [];
         if (!this.registerScriptEvents(config)) {
           this.statusBarItem.hide();
         }
@@ -132,7 +136,6 @@ export class StatusBarCommand implements vscode.Disposable {
         disposables.push(${config.scriptEvents.map(obj => `${obj}(runScript)`).join(', ')});
         runScript();
       `;
-      this.scriptEventDisposables = [];
       try {
         this.runInNewContext(script, {
           disposables: this.scriptEventDisposables,

--- a/src/statusBarCommand.ts
+++ b/src/statusBarCommand.ts
@@ -100,7 +100,11 @@ export class StatusBarCommand implements vscode.Disposable {
     if (this.runInNewContext && config.scriptEvents && (config.script || config.scriptFile)) {
 
       if (config.scriptFile) {
-        config.script = fs.readFileSync(config.scriptFile, {encoding: 'utf-8'});
+        try {
+          config.script = fs.readFileSync(config.scriptFile, { encoding: 'utf-8' });
+        } catch (err) {
+          this.log(err);
+        }
       }
 
       const script = `

--- a/src/statusBarCommand.ts
+++ b/src/statusBarCommand.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { StatusBarItemConfig } from './statusBarItemConfig';
 
@@ -88,7 +89,7 @@ export class StatusBarCommand implements vscode.Disposable {
     if (this.listensToActiveTextEditorChange) {
       this.disposables.push(vscode.window.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor, this));
       this.onDidChangeActiveTextEditor(vscode.window.activeTextEditor);
-    } else if (config.scriptEvents && config.script) {
+    } else if (config.scriptEvents && (config.script || config.scriptFile)) {
       if (!this.registerScriptEvents(config)) {
         this.statusBarItem.hide();
       }
@@ -96,7 +97,11 @@ export class StatusBarCommand implements vscode.Disposable {
   }
 
   private registerScriptEvents(config: StatusBarItemConfig) {
-    if (this.runInNewContext && config.scriptEvents && config.script) {
+    if (this.runInNewContext && config.scriptEvents && (config.script || config.scriptFile)) {
+
+      if (config.scriptFile) {
+        config.script = fs.readFileSync(config.scriptFile, {encoding: 'utf-8'});
+      }
 
       const script = `
         function runScript(event){

--- a/src/statusBarItemConfig.ts
+++ b/src/statusBarItemConfig.ts
@@ -146,4 +146,9 @@ export interface StatusBarItemConfig {
      * e.g. evt.affectsConfiguration('http') ? statusBarItem.text = 'http changed' : statusBarItem.text = 'http not changed'
      */
      script?: string;
+
+     /**
+      * File to read script from
+      */
+     scriptFile?: string;
 }


### PR DESCRIPTION
Hi @AnWeber, do you have any sympathy for this feature?

My current use case is displaying information about the git repo I'm currently working in (it's Scala, and I'm displaying information about the "[build server](https://scalacenter.github.io/bloop/)" project that the current file may or may not be part of.) Specifically, if `vscode.window.activeTextEditor.document.uri.path` matches a certain pattern, then I use that pattern to locate a certain symlink, and display the file name that the symlink is pointing to using `fs.readlinkSync`. That's a bit too much code complexity to fit in one line inside a string in `settings.json`. (I did consider a hack using `eval` and `readFileSync` to avoid asking you for this feature, but `require` didn't work in the `eval`).

If you are willing to add this, would you mind helping me make it compatible with your `compile-web` target? It seems that we would need to make this feature conditional on the platform?
