### PR TITLE
Add support string array for script code

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,10 @@
                                 "description": "list of events"
                             },
                             "script": {
-                                "type": "string",
+                                "type": [
+                                    "string",
+                                    "array"
+                                ],
                                 "description": "script to execute if event is triggered"
                             },
                             "scriptFile": {
@@ -309,7 +312,10 @@
                                 "description": "list of events"
                             },
                             "script": {
-                                "type": "string",
+                                "type": [
+                                    "string",
+                                    "array"
+                                ],
                                 "description": "script to execute if event is triggered"
                             },
                             "scriptFile": {

--- a/src/statusBarCommand.ts
+++ b/src/statusBarCommand.ts
@@ -104,7 +104,7 @@ export class StatusBarCommand implements vscode.Disposable {
             if(documentUri){
               workspaceFolder = vscode.workspace.getWorkspaceFolder(documentUri)?.uri;
             }
-            ${this.config.script}
+            ${typeof this.config.script == 'string' ? this.config.script : this.config.script.join(';')}
             validateStatusBarItem();
           }catch(err){
             log(err);

--- a/src/statusBarItemConfig.ts
+++ b/src/statusBarItemConfig.ts
@@ -149,7 +149,7 @@ export interface StatusBarItemConfig {
    * script to execute if event is triggered
    * e.g. evt.affectsConfiguration('http') ? statusBarItem.text = 'http changed' : statusBarItem.text = 'http not changed'
    */
-  script?: string;
+  script?: string | Array<string>;
 
   /**
    * File to read script from


### PR DESCRIPTION
Example of usage:
```json
{
    "alignment": "left",
    "priority": -15,
    "text": "$(bug)",
    "color": "#ff8080",
    "scriptEvents": [
        "vscode.debug.onDidChangeActiveDebugSession"
    ],
    "script": [
        "let active = !!vscode.debug.activeDebugSession",
        "statusBarItem.command = active ? 'workbench.debug.action.toggleRepl' : 'workbench.action.debug.start'",
        "statusBarItem.text = active ? ('$(bug)'+vscode.debug.activeDebugSession.name) : '$(bug)'",
        "statusBarItem.tooltip = active ? 'Show console' : 'Start debuger'"
    ]
}
```